### PR TITLE
Use temporary redirect code while domain move to zappi.io is being rolled out

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @itskingori @tsu-shiuan @zacblazic
+* @Intellection/devops

--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,9 @@ echo "Validating required environment variables"
 : ${REDIRECT_TARGET:?"You need to set the REDIRECT_TARGET environment variable."}
 
 # Set default redirect code
-REDIRECT_CODE="${REDIRECT_CODE:=301}"
+# TODO
+# Change redirect code back to 301 once domain move to zappi.io is complete
+REDIRECT_CODE="${REDIRECT_CODE:=302}"
 
 # Add http if not set
 if ! [[ ${REDIRECT_TARGET} =~ ^https?:// ]]; then


### PR DESCRIPTION
What it says on the tin.