### PR TITLE
Support absolute redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.0
+
+* Enable ability to ignore request URIs to support absolute redirection.
+* Upgrade to Nginx 1.17.
+
 ## 1.1.0
 
 * Enable configuration of redirect status code via `REDIRECT_CODE` environment variable.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.15-alpine
+FROM nginx:1.17-alpine
 
 COPY start.sh /usr/local/bin/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,6 @@ services:
     ports:
       - "3000:80"
     environment:
-      REDIRECT_TARGET: "zappi.io"
+      REDIRECT_CODE: "302"
+      REDIRECT_TARGET: "https://www.zappi.io"
+      IGNORE_REQUEST_URI: "true"

--- a/start.sh
+++ b/start.sh
@@ -5,8 +5,12 @@ set -eu
 echo "Validating required environment variables"
 : ${REDIRECT_TARGET:?"You need to set the REDIRECT_TARGET environment variable."}
 
-# Set default redirect code
+# Set defaults
 REDIRECT_CODE="${REDIRECT_CODE:=301}"
+IGNORE_REQUEST_URI="${IGNORE_REQUEST_URI:=false}"
+
+# Set variables
+NGINX_CONFIG_FILE="/etc/nginx/conf.d/default.conf"
 
 # Add http if not set
 if ! [[ ${REDIRECT_TARGET} =~ ^https?:// ]]; then
@@ -20,12 +24,20 @@ fi
 
 echo "Redirecting to ${REDIRECT_TARGET} with status code ${REDIRECT_CODE}"
 
-cat <<EOF > /etc/nginx/conf.d/default.conf
+if [[ ${IGNORE_REQUEST_URI} = "true" ]]; then
+  cat <<- EOF > ${NGINX_CONFIG_FILE}
 server {
-	listen 80;
-
+  listen 80;
+  return ${REDIRECT_CODE} ${REDIRECT_TARGET};
+}
+EOF
+else
+  cat <<- EOF > ${NGINX_CONFIG_FILE}
+server {
+  listen 80;
   return ${REDIRECT_CODE} ${REDIRECT_TARGET}\$request_uri;
 }
 EOF
+fi
 
 exec nginx -g "daemon off;"


### PR DESCRIPTION
Setting `IGNORE_REQUEST_URI` to `true` will no longer append the [`$request_uri`](http://nginx.org/en/docs/http/ngx_http_core_module.html#var_request_uri) (i.e. the original request path) to the redirect target. 

This enables "absolute" redirects where the user will always be redirected to a specific location irrespective of what path they request with.

Additionally, this upgrades Nginx to 1.17.