### PR TITLE
Avoid adding trailing slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.1
+
+* Avoid adding trailing slash.
+
 ## 1.2.0
 
 * Enable ability to ignore request URIs to support absolute redirection.

--- a/start.sh
+++ b/start.sh
@@ -17,11 +17,6 @@ if ! [[ ${REDIRECT_TARGET} =~ ^https?:// ]]; then
 	REDIRECT_TARGET="http://${REDIRECT_TARGET}"
 fi
 
-# Add trailing slash
-if [[ ${REDIRECT_TARGET:(-1)} != "/" ]]; then
-	REDIRECT_TARGET="${REDIRECT_TARGET}/"
-fi
-
 echo "Redirecting to ${REDIRECT_TARGET} with status code ${REDIRECT_CODE}"
 
 if [[ ${IGNORE_REQUEST_URI} = "true" ]]; then


### PR DESCRIPTION
I think we should let the user do this explicitly instead of having it done implicitly because it can cause weird behaviour. For example, this causes a double slash to occur when `$request_uri` is appended to it ...

```
return ${REDIRECT_CODE} ${REDIRECT_TARGET}\$request_uri;
```

This is because `$request_uri` will always have a `/` at the beginning. That said, I'm not 💯% sure this is the right thing to do because @zacblazic has more context around why he added it (https://github.com/Intellection/docker-redirector/commit/6baa6f076b452254ddb4031753e0a0ff908f90ed). But one thing I do know if that it seems we updated this image to v1.2.0 but never updated apps to use is. FYI, [the diff between 1.1.0 and 1.2.0 can be seen here](https://github.com/Intellection/docker-redirector/compare/1.1.0...Intellection:1.2.0).