### PR TITLE
Run as unprivileged user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.0
+
+* Change base image to `zappi/nginx` which enables running as unprivileged user `nginx`.
+* Remove permission fix as these are in the base image.
+* Use port `8080` instead of `80`.
+
 ## 1.5.0
 
 * Set `STOPSIGNAL` to `SIGQUIT`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,6 @@ RUN apk add --update bash \
 	&& rm -rf /var/cache/apk/* \
 	&& chmod +x /usr/local/bin/start.sh
 
-# Fix permission issue
-RUN chown -R nginx:nginx /var/cache/nginx && \
-    chmod -R g+w /var/cache/nginx
-
 USER nginx:nginx
 STOPSIGNAL SIGQUIT
 CMD ["start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.17-alpine
+FROM zappi/nginx:1.17.7-3
 
 COPY start.sh /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM zappi/nginx:1.17.7-3
 
 COPY start.sh /usr/local/bin/
 
+USER root
 RUN apk add --update bash \
 	&& rm -rf /var/cache/apk/* \
 	&& chmod +x /usr/local/bin/start.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker Redirector
 
-Listens on port `80` and redirects all web traffic to a given target.
+Listens on port `8080` and redirects all web traffic to a given target.
 
 ## Features
 
@@ -33,7 +33,7 @@ By default redirects are permantent. To change the default status code you can s
 To start a container that will redirect to `example.com` using the plain docker command run:
 
 ```console
-$ docker run --rm -d -e REDIRECT_TARGET=example.com -p 80:80 zappi/redirector
+$ docker run --rm -d -e REDIRECT_TARGET=example.com -p 8080:8080 zappi/redirector
 ```
 
 ### Docker Compose
@@ -47,7 +47,7 @@ services:
   redirect:
     image: zappi/redirector
     ports:
-      - 80
+      - "8080:8080"
     environment:
       REDIRECT_TARGET: "example.com"
       REDIRECT_CODE: "302"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: redirector
     build: .
     ports:
-      - "3000:80"
+      - "8080:8080"
     environment:
       REDIRECT_CODE: "302"
       REDIRECT_TARGET: "https://www.zappi.io"

--- a/start.sh
+++ b/start.sh
@@ -22,14 +22,14 @@ echo "Redirecting to ${REDIRECT_TARGET} with status code ${REDIRECT_CODE}"
 if [[ ${IGNORE_REQUEST_URI} = "true" ]]; then
   cat <<- EOF > ${NGINX_CONFIG_FILE}
 server {
-  listen 80;
+  listen 8080;
   return ${REDIRECT_CODE} ${REDIRECT_TARGET};
 }
 EOF
 else
   cat <<- EOF > ${NGINX_CONFIG_FILE}
 server {
-  listen 80;
+  listen 8080;
   return ${REDIRECT_CODE} ${REDIRECT_TARGET}\$request_uri;
 }
 EOF


### PR DESCRIPTION
This ensures that we can run as the unprivileged user `nginx` on port `8080`.

Related: https://github.com/Intellection/docker-nginx/pull/6.